### PR TITLE
fix(api): use priority_fee as validator reward when block_rewards is …

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
@@ -67,9 +67,28 @@ defmodule BlockScoutWeb.API.V2.BlockView do
     |> chain_type_fields(block, single_block?)
   end
 
+  # When block has no rewards in DB (e.g. chain doesn't support fetch_beneficiaries), use priority_fee as validator reward
+  def prepare_rewards(rewards, block, single_block?)
+      when rewards in [nil, []] do
+    case fallback_reward_from_priority_fee(block) do
+      nil -> []
+      reward_map -> [reward_map]
+    end
+  end
+
   def prepare_rewards(rewards, block, single_block?) do
     Enum.map(rewards, &prepare_reward(&1, block, single_block?))
   end
+
+  defp fallback_reward_from_priority_fee(%{priority_fees: priority_fees})
+       when not is_nil(priority_fees) do
+    case Decimal.compare(priority_fees, 0) do
+      :gt -> %{"reward" => Decimal.to_string(Decimal.round(priority_fees)), "type" => "validator"}
+      _ -> nil
+    end
+  end
+
+  defp fallback_reward_from_priority_fee(_block), do: nil
 
   def prepare_reward(reward, block, single_block?) do
     %{


### PR DESCRIPTION
## Summary
Fixes the blocks-validated API returning `"rewards": []` for chains where block rewards are not stored (e.g. Geth/Oasys).

## Problem
- `/api/v2/addresses/:address_hash/blocks-validated` reads `rewards` from the `block_rewards` table.
- On Geth, `fetch_beneficiaries` returns `:ignore`, so the indexer never writes block rewards → API always returns empty rewards.
- Frontend/consumers expect a validator reward (e.g. `[{ "reward": "...", "type": "validator" }]`).

## Solution
- In API v2 BlockView, when `rewards` is nil or empty and the block has `priority_fees` > 0, return a single validator reward using the block’s priority fee.
- Reward value is formatted as an integer string to match the existing API schema.

## Changes
- `apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex`: added fallback in `prepare_rewards/3` and `fallback_reward_from_priority_fee/1`.
- No DB or indexer changes; behaviour only affects the API response when no block_rewards exist.